### PR TITLE
Fix inversion links/description in angular samples

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -39,8 +39,8 @@ Samples around the Microsoft Graph API demonstrate different capabilities and po
 
 ## Angular
 
-- [angular-connect-rest](./angular-connect-rest) - Microsoft Graph Connect Sample for Angular 4
-- [angular-connect](./angular-connect) - Microsoft Graph Connect Sample for AngularJS (REST)
+- [angular-connect-rest](./angular-connect-rest) -  Microsoft Graph Connect Sample for AngularJS (REST)
+- [angular-connect](./angular-connect) - Microsoft Graph Connect Sample for Angular 4
 - [angular-excelstarter](./angular-excelstarter) - Microsoft Graph Excel Starter Sample for Angular 4
 - [angular-snippets-rest](./angular-snippets-rest) - Microsoft Graph Snippets Sample for AngularJS (REST)
 


### PR DESCRIPTION
Fixes an inversion in the angular samples. Links and description had been swapped for two samples.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        |  yes                               |
| New sample?     | no                             |
| New tutorial?   | no                               |
| Related issues? | fixes #X, partially #Y, mentioned in #Z |

## What's in this Pull Request?

In the Angular section of the README.md for samples, the first 2 samples had a description which did not match the hyperlink, but the other sample's hyperlink
