### PR TITLE
adding authors mention in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,6 +15,12 @@
 > _(DELETE THIS PARAGRAPH AFTER READING)_
 >
 
+## Authors
+
+> Because of the way this repository is setup, samples authors do not get a notification when you create an issue. *It makes it less likely for you to get your issue resolved or to get help*. For the section above **@mention any author of the sample**. Authors' github handle can be found on the main sample documentation page, under the "contributors" section. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
+> 
+> _(DELETE THIS PARAGRAPH AFTER READING)_
+
 ## Expected or Desired Behavior
 
 > If you are reporting a bug, please describe the expected behavior. If you are suggesting an enhancement please describe thoroughly the enhancement, how it can be achieved, and expected benefit.


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New sample?     | no                               |
| New tutorial?   | no                               |
| Related issues? |  |

## What's in this Pull Request?
Adding a section to mention the authors in the issue submission template so the get notified when something is wrong with their template and issue creators are more likely to get an answer.
